### PR TITLE
channel and message can now be "0", "", " " etc.

### DIFF
--- a/composer/lib/Pubnub/Pubnub.php
+++ b/composer/lib/Pubnub/Pubnub.php
@@ -122,7 +122,7 @@ class Pubnub
      */
     public function publish($channel, $messageOrg, $storeInHistory = true)
     {
-        if (empty($channel) || empty($messageOrg)) {
+        if (!isset($channel) || !isset($messageOrg)) {
             throw new PubnubException('Missing Channel or Message in publish()');
         }
 


### PR DESCRIPTION
`empty()` evaluates " " and "0" as true where `!isset()` evaluates these as false
This will allow us to publish messages such as "0".
If there should never be channels named " ", "0" or any other value evaluated as true by `empty()` then you may change the channel check back but I would think "0" is acceptable. As for message, this should surely be `!isset()` or something more complex than `empty()`.
